### PR TITLE
Add module info and fix build for Java 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /.settings/
 /.classpath
 /.project
+
+*.iml
+
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -36,15 +36,15 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.target>1.6</maven.compiler.target>
-		<maven.compiler.source>1.6</maven.compiler.source>
+		<maven.compiler.target>9</maven.compiler.target>
+		<maven.compiler.source>9</maven.compiler.source>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.6</version>
+			<version>2.8.8</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -90,31 +90,6 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.2.2</version>
-				<configuration>
-					<outputDirectory>${project.build.directory}/original</outputDirectory>
-					<createDependencyReducedPom>false</createDependencyReducedPom>
-					<filters>
-						<filter>
-							<artifact>*:*</artifact>
-							<excludes>
-								<exclude>module-info.class</exclude>
-							</excludes>
-						</filter>
-					</filters>
-				</configuration>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 				<version>3.1.0</version>
 				<executions>
@@ -154,6 +129,15 @@
 		                    </script>
 		                ]]>
 					</bottom>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<source>9</source>
+					<target>9</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module unique4j {
+    requires com.google.gson;
+    exports in.pratanumandal.unique4j;
+    exports in.pratanumandal.unique4j.exception;
+}


### PR DESCRIPTION
Hi Pratanu :)
I recently upgraded all my projects to the latest Java version including the introduction of modules in Java 9. To make a long story short: I had to create `module-info.java` files for all of my dependencies and thought to share that with you. 

Before you merge though: Merging this PR makes Unique4J incompatible with Java 6, 7 and 8 and requires Java 9 or higher. If you don't care about that feel free to merge. If you do care, I would suggest to create 2 jars: One that includes the module-info.java, making Java9 users happy and one that doesn't, making support for Java 8 and lower possible.

Feel free to contact me if you have any questions :)
Cheers,
Vatbub